### PR TITLE
Add simple Daily English Story web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Daily English Story for Kids</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="main-container">
+    <h1>Today's Story</h1>
+    <img id="story-image" src="" alt="Story image" />
+    <div id="story-text-container"></div>
+    <div class="navigation">
+      <button id="prev-day-btn">Previous</button>
+      <button id="next-day-btn">Next</button>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,97 @@
+// Hardcoded data for each day's story
+const dailyStories = [
+  {
+    day: 1,
+    image: "https://placehold.co/600x400/FFDDC1/333333?text=A+Sunny+Day",
+    sentences: [
+      { en: "The sun is shining.", cn: "太阳在发光。" },
+      { en: "A happy dog is running on the grass.", cn: "一只快乐的狗在草地上跑。" },
+      { en: "It is a beautiful day!", cn: "真是美好的一天！" }
+    ]
+  },
+  {
+    day: 2,
+    image: "https://placehold.co/600x400/A2E4B8/333333?text=In+the+Forest",
+    sentences: [
+      { en: "This is a big green forest.", cn: "这是一片绿色的大森林。" },
+      { en: "A little bird is singing on a branch.", cn: "一只小鸟在树枝上唱歌。" }
+    ]
+  },
+  {
+    day: 3,
+    image: "https://placehold.co/600x400/B2CCFF/333333?text=Bedtime+Story",
+    sentences: [
+      { en: "The moon is in the sky.", cn: "月亮在天空中。" },
+      { en: "It is time to go to sleep.", cn: "是时候睡觉了。" },
+      { en: "Good night, little star.", cn: "晚安，小星星。" }
+    ]
+  }
+];
+
+let currentDayIndex = 0;
+
+const imageEl = document.getElementById('story-image');
+const textContainer = document.getElementById('story-text-container');
+const prevBtn = document.getElementById('prev-day-btn');
+const nextBtn = document.getElementById('next-day-btn');
+
+function renderStory(index) {
+  const story = dailyStories[index];
+  imageEl.src = story.image;
+  textContainer.innerHTML = '';
+
+  story.sentences.forEach((sentence) => {
+    const p = document.createElement('p');
+    p.textContent = sentence.en;
+    textContainer.appendChild(p);
+
+    let pressTimer;
+
+    p.addEventListener('mousedown', () => {
+      pressTimer = setTimeout(() => {
+        alert(sentence.cn);
+        p.dataset.longPress = 'true';
+      }, 800);
+    });
+
+    ['mouseup', 'mouseleave'].forEach((evt) => {
+      p.addEventListener(evt, () => clearTimeout(pressTimer));
+    });
+
+    p.addEventListener('click', () => {
+      if (p.dataset.longPress === 'true') {
+        p.dataset.longPress = 'false';
+        return;
+      }
+      if (p.dataset.clicked === 'true') {
+        alert(sentence.cn);
+        p.dataset.clicked = 'false';
+      } else {
+        const utterance = new SpeechSynthesisUtterance(sentence.en);
+        speechSynthesis.speak(utterance);
+        p.dataset.clicked = 'true';
+      }
+    });
+  });
+
+  prevBtn.disabled = index === 0;
+  nextBtn.disabled = index === dailyStories.length - 1;
+}
+
+prevBtn.addEventListener('click', () => {
+  if (currentDayIndex > 0) {
+    currentDayIndex--;
+    renderStory(currentDayIndex);
+  }
+});
+
+nextBtn.addEventListener('click', () => {
+  if (currentDayIndex < dailyStories.length - 1) {
+    currentDayIndex++;
+    renderStory(currentDayIndex);
+  }
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  renderStory(currentDayIndex);
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,69 @@
+/* Simple, child-friendly styles */
+body {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  font-family: 'Arial', 'Helvetica', sans-serif;
+  background-color: #f5f5f5;
+}
+
+.main-container {
+  width: 100%;
+  max-width: 800px;
+  padding: 20px;
+  background-color: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+#story-image {
+  width: 100%;
+  height: 300px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+#story-text-container p {
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 6px;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+#story-text-container p:hover {
+  background-color: #f0f0f0;
+}
+
+.navigation {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+
+button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 20px;
+  background-color: #ff8c00;
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+button:hover {
+  background-color: #ffa733;
+}
+
+button:active {
+  transform: scale(0.98);
+}
+
+button:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- Add basic HTML layout with image display, story text container, and navigation buttons for a children's daily English story app.
- Style the page with a centered card layout, responsive image, interactive sentences, and colorful navigation controls.
- Implement story rendering, speech synthesis for sentences, translation via repeat click or long press, and day navigation logic with disabled states.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c0731468832899acd2a207b46d14