### PR TITLE
feat: toggle translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # codex-demo
+
+Demo page that displays short daily English stories for kids.
+Click a sentence to hear it or long press to see its Chinese translation.
+Use the **Show Translations** button to reveal or hide all Chinese sentences.
+

--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
     <h1>Today's Story</h1>
     <img id="story-image" src="" alt="Story image" />
     <div id="story-text-container"></div>
+    <div class="controls">
+      <button id="toggle-translations-btn">Show Translations</button>
+    </div>
     <div class="navigation">
       <button id="prev-day-btn">Previous</button>
       <button id="next-day-btn">Next</button>

--- a/script.js
+++ b/script.js
@@ -30,10 +30,13 @@ const dailyStories = [
 
 let currentDayIndex = 0;
 
+let showTranslations = false;
+
 const imageEl = document.getElementById('story-image');
 const textContainer = document.getElementById('story-text-container');
 const prevBtn = document.getElementById('prev-day-btn');
 const nextBtn = document.getElementById('next-day-btn');
+const toggleBtn = document.getElementById('toggle-translations-btn');
 
 function renderStory(index) {
   const story = dailyStories[index];
@@ -45,11 +48,19 @@ function renderStory(index) {
     p.textContent = sentence.en;
     textContainer.appendChild(p);
 
+    const cn = document.createElement('p');
+    cn.textContent = sentence.cn;
+    cn.className = 'translation';
+    cn.style.display = showTranslations ? 'block' : 'none';
+    textContainer.appendChild(cn);
+
     let pressTimer;
 
     p.addEventListener('mousedown', () => {
       pressTimer = setTimeout(() => {
-        alert(sentence.cn);
+        if (!showTranslations) {
+          alert(sentence.cn);
+        }
         p.dataset.longPress = 'true';
       }, 800);
     });
@@ -64,7 +75,9 @@ function renderStory(index) {
         return;
       }
       if (p.dataset.clicked === 'true') {
-        alert(sentence.cn);
+        if (!showTranslations) {
+          alert(sentence.cn);
+        }
         p.dataset.clicked = 'false';
       } else {
         const utterance = new SpeechSynthesisUtterance(sentence.en);
@@ -90,6 +103,12 @@ nextBtn.addEventListener('click', () => {
     currentDayIndex++;
     renderStory(currentDayIndex);
   }
+});
+
+toggleBtn.addEventListener('click', () => {
+  showTranslations = !showTranslations;
+  toggleBtn.textContent = showTranslations ? 'Hide Translations' : 'Show Translations';
+  renderStory(currentDayIndex);
 });
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/style.css
+++ b/style.css
@@ -38,6 +38,16 @@ body {
   background-color: #f0f0f0;
 }
 
+.controls {
+  margin-top: 20px;
+}
+
+.translation {
+  font-size: 1.1rem;
+  color: #555;
+  display: none;
+}
+
 .navigation {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add 'Show Translations' button to display or hide Chinese sentences
- style translation and controls
- document translation toggle in README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a42cb989c08328bd765ecce66a2bee